### PR TITLE
fix: Avoid linebreak in balance label

### DIFF
--- a/nanobrowse/templates/account_viewer/account_info.html
+++ b/nanobrowse/templates/account_viewer/account_info.html
@@ -4,7 +4,7 @@
           <!-- Balance -->
           <tr>
             <td data-show-table="transactionTable" style="cursor:pointer" class="bg-blue-500 text-white text-xs px-3 rounded w-32 h-6 flex items-center justify-center">
-              Available Balance
+              Balance
             </td>
             <td class="px-3 py-1 font-bold">{{account_data['confirmed_balance'] }}</td>
           </tr>


### PR DESCRIPTION
With my setup, there is a linebreak in the "Available Balance" label:
![acc1](https://github.com/user-attachments/assets/e9231a80-7acc-4a9f-901b-ee6d58ec67a9)


I think the "available" doesn't add any significant info, so I suggest just removing this "prefix".