### PR TITLE
Fix button highlights and add flow grouping tooltip

### DIFF
--- a/nanobrowse/static/js/account_history.js
+++ b/nanobrowse/static/js/account_history.js
@@ -50,8 +50,31 @@ document.addEventListener('click', function(event) {
   
     // Toggle table display if a valid target is found
     if (targetElement && targetElement.getAttribute('data-show-table')) {
-    manuallyToggled = targetElement.getAttribute('data-show-table');
-  
+      manuallyToggled = targetElement.getAttribute('data-show-table');
+
+      switch (targetElement.getAttribute('data-show-table')) {
+        case 'transactionTable':
+          document.getElementById('tableSubBtns').classList.remove('hidden');
+          document.getElementById('tableSubBtns').classList.add('flex');
+          highlight(['transactionTableBtn', 'transactionTableSubBtn']);
+          break;
+        case 'groupedTransactionTable':
+          document.getElementById('tableSubBtns').classList.remove('hidden');
+          document.getElementById('tableSubBtns').classList.add('flex');
+          highlight(['transactionTableBtn', 'groupedTransactionTableSubBtn']);
+          break;
+        case 'receivableTable':
+          document.getElementById('tableSubBtns').classList.add('hidden');
+          document.getElementById('tableSubBtns').classList.remove('flex');
+          highlight(['receivableTableBtn']);
+          break;
+        case 'delegatorTable':
+          document.getElementById('tableSubBtns').classList.add('hidden');
+          document.getElementById('tableSubBtns').classList.remove('flex');
+          highlight(['delegatorTableBtn']);
+          break;
+      }
+
       const targetTableID = targetElement.getAttribute('data-show-table');
       document.querySelectorAll('.table').forEach(table => table.style.display = 'none');
       const targetTable = document.getElementById(targetTableID);
@@ -62,4 +85,20 @@ document.addEventListener('click', function(event) {
       }
     }
   });
-  
+
+function highlight(ids) {
+  // Reset color of all table-selection buttons:
+  document.querySelectorAll(`[data-show-table]`).forEach(element => {
+    element.classList.add(element.getAttribute('data-default-color'));
+    element.classList.remove(element.getAttribute('data-active-color'));
+  });
+
+  // Highlight given elements:
+  ids.forEach(id => {
+    let element = document.getElementById(id);
+    if (element) {
+      element.classList.remove(element.getAttribute('data-default-color'));
+      element.classList.add(element.getAttribute('data-active-color'));
+    }
+  });
+}

--- a/nanobrowse/templates/account_viewer.html
+++ b/nanobrowse/templates/account_viewer.html
@@ -81,6 +81,7 @@
           data-active-color="bg-blue-500"
           data-show-table="groupedTransactionTable"
           class="bg-gray-800 text-white px-3 py-1 rounded focus:outline-none"
+          title="Group transactions by type and account and sort by amount."
         >
           Grouped Flows
         </button>

--- a/nanobrowse/templates/account_viewer.html
+++ b/nanobrowse/templates/account_viewer.html
@@ -72,8 +72,13 @@
 
       {% include 'account_viewer/account_info.html' %}
 
-      <div class="mt-4 text-xs flex items-center justify-center space-x-2">
+      <div
+        id="tableSubBtns"
+        class="mt-4 text-xs flex items-center justify-center space-x-2">
         <button
+          id="groupedTransactionTableSubBtn"
+          data-default-color="bg-gray-800"
+          data-active-color="bg-blue-500"
           data-show-table="groupedTransactionTable"
           class="bg-gray-800 text-white px-3 py-1 rounded focus:outline-none"
         >
@@ -81,8 +86,11 @@
         </button>
 
         <button
+          id="transactionTableSubBtn"
+          data-default-color="bg-gray-800"
+          data-active-color="bg-blue-500"
           data-show-table="transactionTable"
-          class="bg-gray-800 text-white px-3 py-1 rounded focus:outline-none"
+          class="bg-blue-500 text-white px-3 py-1 rounded focus:outline-none"
         >
           Timeline
         </button>

--- a/nanobrowse/templates/account_viewer/account_info.html
+++ b/nanobrowse/templates/account_viewer/account_info.html
@@ -3,7 +3,13 @@
         <tbody>
           <!-- Balance -->
           <tr>
-            <td data-show-table="transactionTable" style="cursor:pointer" class="bg-blue-500 text-white text-xs px-3 rounded w-32 h-6 flex items-center justify-center">
+            <td
+              data-show-table="transactionTable"
+              style="cursor:pointer"
+              id="transactionTableBtn"
+              data-default-color="bg-gray-700"
+              data-active-color="bg-blue-500"
+              class="bg-blue-500 text-white text-xs px-3 rounded w-32 h-6 flex items-center justify-center">
               Available Balance
             </td>
             <td class="px-3 py-1 font-bold">{{account_data['confirmed_balance'] }}</td>
@@ -12,7 +18,13 @@
           {% if account_data['show_receivable'] %}
           <!-- Receivable balance -->
           <tr>
-            <td data-show-table="receivableTable" style="cursor:pointer" class="bg-gray-700 text-white text-xs px-3 rounded w-32 h-8 flex flex-col items-center justify-center">
+            <td
+              data-show-table="receivableTable"
+              style="cursor:pointer"
+              id="receivableTableBtn"
+              data-default-color="bg-gray-700"
+              data-active-color="bg-blue-500"
+              class="bg-gray-700 text-white text-xs px-3 rounded w-32 h-8 flex flex-col items-center justify-center">
               <div>Ready to receive</div>
               <!-- <div>({{account_data['receivable_count'] }} blocks)</div> -->
             </td>
@@ -23,7 +35,13 @@
           {% if account_data['show_weight'] %}
           <!-- Weight -->
           <tr>
-            <td data-show-table="delegatorTable" style="cursor:pointer" class="bg-gray-700 text-white text-xs px-3 rounded w-32 h-6 flex items-center justify-center">
+            <td
+              data-show-table="delegatorTable"
+              style="cursor:pointer"
+              id="delegatorTableBtn"
+              data-default-color="bg-gray-700"
+              data-active-color="bg-blue-500"
+              class="bg-gray-700 text-white text-xs px-3 rounded w-32 h-6 flex items-center justify-center">
               Weight
             </td>
             <td class="px-3 py-1 font-bold">{{account_data['weight_formatted'] }}</td>


### PR DESCRIPTION
This PR fixes #5 and also hides the two "Grouped Flow" and "Timeline" buttons, if they are not applicable to the selected "tab".

Additionally, I have added a small tooltip for the "Grouped Flow" button, because I found it confusing without.